### PR TITLE
#14 예약취소 바텀시트 초기화 관련 수정

### DIFF
--- a/app/src/main/java/com/sookmyung/carryus/ui/reservationlist/detail/CancelBottomSheetViewModel.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/reservationlist/detail/CancelBottomSheetViewModel.kt
@@ -13,6 +13,10 @@ class CancelBottomSheetViewModel : ViewModel() {
     private val _textCount = MutableLiveData<String>()
     val textCount: LiveData<String> = _textCount
 
+    init {
+        _textCount.value = "0/1000"
+    }
+
     companion object{
         private const val MAXIMUM_LENGTH = 1000
     }


### PR DESCRIPTION
# 📑 Summary
* 예약취소 바텀시트 초기화 관련 수정했습니다.,....ㅎㅎㅎㅎ
* 제대로 테스트를 안해봤나봐요 ㅎㅎ...

## 📸 Screen Shot
<img width="266" alt="image" src="https://github.com/CARRY-US/CarryUs-Android/assets/90668082/82e925c0-c85f-4028-acb4-138ad011434f">


## ➰ Associated Issue
* close #14 

### 📬 To Reviewers
* 초기화를 xml에서 하니까 'Parameter specified as non-null is null' 에러가 떠서 다시 초기화 코드 추가했습니다 !
