### PR TITLE
#24 위치 기반 스토어 정보 조회

### DIFF
--- a/app/src/main/java/com/sookmyung/carryus/data/entitiy/response/LocationStoreResponse.kt
+++ b/app/src/main/java/com/sookmyung/carryus/data/entitiy/response/LocationStoreResponse.kt
@@ -1,0 +1,24 @@
+package com.sookmyung.carryus.data.entitiy.response
+
+import com.sookmyung.carryus.domain.entity.LocationStore
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LocationStoreResponse(
+    @SerialName("storeId") val storeId: Int,
+    @SerialName("storeImgUrl") val storeImgUrl: String,
+    @SerialName("storeName") val storeName: String,
+    @SerialName("storeLocation") val storeLocation: String,
+    @SerialName("storeReviewCount") val storeReviewCount: Int,
+    @SerialName("storeRatingAverage") val storeRatingAverage: Double
+) {
+    fun toLocationStore(): LocationStore = LocationStore(
+        storeId = this.storeId,
+        storeImgUrl = this.storeImgUrl,
+        storeName = this.storeName,
+        storeLocation = this.storeLocation,
+        storeReviewCount = this.storeReviewCount.toString(),
+        storeRatingAverage = this.storeRatingAverage.toString()
+    )
+}

--- a/app/src/main/java/com/sookmyung/carryus/data/repositoryImpl/MainRepositoryImpl.kt
+++ b/app/src/main/java/com/sookmyung/carryus/data/repositoryImpl/MainRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.sookmyung.carryus.data.repositoryImpl
 
 import com.sookmyung.carryus.data.source.MainDataSource
+import com.sookmyung.carryus.domain.entity.LocationStore
 import com.sookmyung.carryus.domain.entity.StoreSearchResult
 import com.sookmyung.carryus.domain.repository.MainRepository
 import javax.inject.Inject
@@ -15,7 +16,16 @@ class MainRepositoryImpl @Inject constructor(
         yMax: Double
     ): Result<List<StoreSearchResult>> = runCatching {
         mainDataSource.getUserLocationStoreList(xMin, xMax, yMin, yMax)
-    }.mapCatching { response -> response.data?.map { it.toStoreSearchResult() } ?: emptyList()
+    }.mapCatching { response ->
+        response.data?.map { it.toStoreSearchResult() } ?: emptyList()
     }
 
+    override suspend fun getLocationStoreList(
+        latitude: Double,
+        longitude: Double
+    ): Result<List<LocationStore>> = runCatching {
+        mainDataSource.getLocationStoreList(latitude, longitude)
+    }.mapCatching { response ->
+        response.data?.map { it.toLocationStore() } ?: emptyList()
+    }
 }

--- a/app/src/main/java/com/sookmyung/carryus/data/service/MainService.kt
+++ b/app/src/main/java/com/sookmyung/carryus/data/service/MainService.kt
@@ -1,6 +1,7 @@
 package com.sookmyung.carryus.data.service
 
 import com.sookmyung.carryus.data.entitiy.BaseResponse
+import com.sookmyung.carryus.data.entitiy.response.LocationStoreResponse
 import com.sookmyung.carryus.data.entitiy.response.UserLocationStoreResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -13,4 +14,10 @@ interface MainService {
         @Query("yMin") yMin: Double,
         @Query("yMax") yMax: Double
     ): BaseResponse<List<UserLocationStoreResponse>>
+
+    @GET("main/stores")
+    suspend fun getLocationStoreList(
+        @Query("x") latitude: Double,
+        @Query("y") longitude: Double
+    ): BaseResponse<List<LocationStoreResponse>>
 }

--- a/app/src/main/java/com/sookmyung/carryus/data/source/MainDataSource.kt
+++ b/app/src/main/java/com/sookmyung/carryus/data/source/MainDataSource.kt
@@ -1,6 +1,7 @@
 package com.sookmyung.carryus.data.source
 
 import com.sookmyung.carryus.data.entitiy.BaseResponse
+import com.sookmyung.carryus.data.entitiy.response.LocationStoreResponse
 import com.sookmyung.carryus.data.entitiy.response.UserLocationStoreResponse
 import com.sookmyung.carryus.data.service.MainService
 import javax.inject.Inject
@@ -15,4 +16,10 @@ class MainDataSource @Inject constructor(
         yMax: Double
     ): BaseResponse<List<UserLocationStoreResponse>> =
         mainService.getUserLocationStoreList(xMin, xMax, yMin, yMax)
+
+    suspend fun getLocationStoreList(
+        latitude: Double,
+        longitude: Double
+    ): BaseResponse<List<LocationStoreResponse>> =
+        mainService.getLocationStoreList(latitude, longitude)
 }

--- a/app/src/main/java/com/sookmyung/carryus/di/RetrofitModule.kt
+++ b/app/src/main/java/com/sookmyung/carryus/di/RetrofitModule.kt
@@ -32,7 +32,7 @@ object RetrofitModule {
     @Provides
     @Singleton
     @CarryUsType
-    fun providesSoftieInterceptor(): Interceptor = Interceptor { chain ->
+    fun providesCarryUsInterceptor(): Interceptor = Interceptor { chain ->
         val request = chain.request()
         var response = chain.proceed(
             request
@@ -47,7 +47,7 @@ object RetrofitModule {
     @Provides
     @Singleton
     @CarryUsType
-    fun providesSoftieOkHttpClient(@CarryUsType interceptor: Interceptor): OkHttpClient =
+    fun providesCarryUsOkHttpClient(@CarryUsType interceptor: Interceptor): OkHttpClient =
         OkHttpClient.Builder()
             .connectTimeout(10, TimeUnit.SECONDS)
             .writeTimeout(10, TimeUnit.SECONDS)
@@ -63,7 +63,7 @@ object RetrofitModule {
     @Provides
     @Singleton
     @CarryUsType
-    fun providesSoftieRetrofit(@CarryUsType okHttpClient: OkHttpClient): Retrofit =
+    fun providesCarryUsRetrofit(@CarryUsType okHttpClient: OkHttpClient): Retrofit =
         Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_URL)
             .client(okHttpClient)

--- a/app/src/main/java/com/sookmyung/carryus/domain/entity/LocationStore.kt
+++ b/app/src/main/java/com/sookmyung/carryus/domain/entity/LocationStore.kt
@@ -1,0 +1,10 @@
+package com.sookmyung.carryus.domain.entity
+
+data class LocationStore(
+    val storeId: Int,
+    val storeImgUrl: String,
+    val storeName: String,
+    val storeLocation: String,
+    val storeReviewCount: String,
+    val storeRatingAverage: String
+)

--- a/app/src/main/java/com/sookmyung/carryus/domain/entity/StoreSearchResult.kt
+++ b/app/src/main/java/com/sookmyung/carryus/domain/entity/StoreSearchResult.kt
@@ -1,5 +1,9 @@
 package com.sookmyung.carryus.domain.entity
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 data class StoreSearchResult(
     val storeId: Int,
     val storeImgUrl: String,
@@ -9,4 +13,4 @@ data class StoreSearchResult(
     val storeRatingAverage: String,
     val latitude: Double,
     val longitude: Double
-)
+) : Parcelable

--- a/app/src/main/java/com/sookmyung/carryus/domain/repository/MainRepository.kt
+++ b/app/src/main/java/com/sookmyung/carryus/domain/repository/MainRepository.kt
@@ -1,7 +1,7 @@
 package com.sookmyung.carryus.domain.repository
 
+import com.sookmyung.carryus.domain.entity.LocationStore
 import com.sookmyung.carryus.domain.entity.StoreSearchResult
-import retrofit2.http.Query
 
 interface MainRepository {
     suspend fun getUserLocationStoreList(
@@ -10,4 +10,9 @@ interface MainRepository {
         yMin: Double,
         yMax: Double
     ): Result<List<StoreSearchResult>>
+
+    suspend fun getLocationStoreList(
+        latitude: Double,
+        longitude: Double
+    ): Result<List<LocationStore>>
 }

--- a/app/src/main/java/com/sookmyung/carryus/domain/usecase/GetLocationStoreList.kt
+++ b/app/src/main/java/com/sookmyung/carryus/domain/usecase/GetLocationStoreList.kt
@@ -1,0 +1,11 @@
+package com.sookmyung.carryus.domain.usecase
+
+import com.sookmyung.carryus.domain.repository.MainRepository
+import javax.inject.Inject
+
+class GetLocationStoreList @Inject constructor(
+    private val mainRepository: MainRepository
+) {
+    suspend operator fun invoke(latitude: Double, longitude: Double) =
+        mainRepository.getLocationStoreList(latitude, longitude)
+}

--- a/app/src/main/java/com/sookmyung/carryus/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/search/SearchFragment.kt
@@ -286,6 +286,7 @@ class SearchFragment :
     // TODO 지도 움직일 때마다, 재검색 버튼이 뜨게 하기
     private fun clickReloadBtn() {
         binding.btnSearchReload.setOnClickListener {
+            viewModel.clickReloadBtn()
             viewModel.updateCurrentPosition(
                 mapView.mapPointBounds.bottomLeft.mapPointGeoCoord.latitude,
                 mapView.mapPointBounds.topRight.mapPointGeoCoord.latitude,

--- a/app/src/main/java/com/sookmyung/carryus/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/search/SearchFragment.kt
@@ -17,16 +17,16 @@ import androidx.core.view.contains
 import androidx.fragment.app.viewModels
 import com.sookmyung.carryus.R
 import com.sookmyung.carryus.databinding.FragmentSearchBinding
+import com.sookmyung.carryus.domain.entity.LocationStore
 import com.sookmyung.carryus.domain.entity.Position
-import com.sookmyung.carryus.domain.entity.StoreSearchResult
 import com.sookmyung.carryus.ui.search.list.SearchListActivity
 import com.sookmyung.carryus.ui.search.result.SearchResultActivity
 import com.sookmyung.carryus.ui.search.storedetail.StoreDetailActivity
+import com.sookmyung.carryus.ui.search.storedetail.StoreDetailActivity.Companion.STORE_ID
 import com.sookmyung.carryus.util.binding.BindingAdapter.setImage
 import com.sookmyung.carryus.util.binding.BindingFragment
 import com.sookmyung.carryus.util.toast
 import dagger.hilt.android.AndroidEntryPoint
-import dagger.hilt.android.lifecycle.HiltViewModel
 import net.daum.mf.map.api.CameraUpdate
 import net.daum.mf.map.api.CameraUpdateFactory
 import net.daum.mf.map.api.MapPOIItem
@@ -35,7 +35,9 @@ import net.daum.mf.map.api.MapView
 import timber.log.Timber
 
 @AndroidEntryPoint
-class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_search) {
+class SearchFragment :
+    BindingFragment<FragmentSearchBinding>(R.layout.fragment_search),
+    MapView.POIItemEventListener {
     private val viewModel by viewModels<SearchViewModel>()
     private lateinit var mapView: MapView
     private lateinit var mapViewContainer: ViewGroup
@@ -66,18 +68,20 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
 
     private fun initMapView() {
         mapView = MapView(activity)
+        mapView.setPOIItemEventListener(this)
+        mapViewContainer = binding.mapSearch
+        mapViewContainer.addView(mapView)
         showMarkerOnMap()
         startTracking()
         moveMapToUserLocation()
-        mapViewContainer = binding.mapSearch
-        mapViewContainer.addView(mapView)
     }
 
     private fun checkLocationPermission() {
         if (ActivityCompat.checkSelfPermission(requireContext(), ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED || ActivityCompat.checkSelfPermission(
-                requireContext(), ACCESS_COARSE_LOCATION
-            ) != PackageManager.PERMISSION_GRANTED
+                    requireContext(),
+                    ACCESS_COARSE_LOCATION
+                ) != PackageManager.PERMISSION_GRANTED
         ) {
             if (ActivityCompat.shouldShowRequestPermissionRationale(
                     requireActivity(),
@@ -99,7 +103,8 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
                     arrayOf(
                         ACCESS_FINE_LOCATION,
                         ACCESS_COARSE_LOCATION
-                    ), LOCATION_PERMISSION_REQUEST_CODE
+                    ),
+                    LOCATION_PERMISSION_REQUEST_CODE
                 )
             }
         }
@@ -122,23 +127,22 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
         requestPermissionLauncher.launch(ACCESS_FINE_LOCATION)
     }
 
-    //TODO marker 클릭 시, 보이게 하기
     private fun initStoreListView() {
-        viewModel.searchStoreList.observe(viewLifecycleOwner) { searchStoreList ->
-            if (searchStoreList == null) {
+        viewModel.locationStoreList.observe(viewLifecycleOwner) { list ->
+            if (list == null) {
                 setViewVisibility(View.GONE, View.GONE)
             } else {
-                when (searchStoreList.size) {
+                when (list.size) {
                     1 -> {
-                        updateStoreInfo(View.VISIBLE, View.GONE, searchStoreList[0])
+                        updateStoreInfo(View.VISIBLE, View.GONE, list[0])
                     }
 
                     2 -> {
                         updateStoreInfo(
                             View.VISIBLE,
                             View.VISIBLE,
-                            searchStoreList[0],
-                            searchStoreList[1]
+                            list[0],
+                            list[1]
                         )
                     }
 
@@ -160,17 +164,17 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
     private fun showMarkerOnMap() {
         mapView.removeAllPOIItems()
         viewModel.searchStoreList.value?.forEach { list ->
-            val marker = MapPoint.mapPointWithGeoCoord(list.latitude, list.longitude)
             val markerIcon = MapPOIItem()
             markerIcon.apply {
                 itemName = list.storeName
+                isShowCalloutBalloonOnTouch = false
                 customImageResourceId = R.drawable.ic_store_default
                 customSelectedImageResourceId = R.drawable.ic_store_select
-                mapPoint = marker
+                mapPoint = MapPoint.mapPointWithGeoCoord(list.latitude, list.longitude)
                 setCustomImageAnchor(0.5f, 0.5f)
                 isCustomImageAutoscale = false
                 markerType = MapPOIItem.MarkerType.CustomImage
-                tag = 0
+                tag = list.storeId
             }
             mapView.addPOIItem(markerIcon)
         }
@@ -219,8 +223,8 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
     private fun updateStoreInfo(
         firstVisibility: Int,
         secondVisibility: Int,
-        firstStoreInfo: StoreSearchResult,
-        secondStoreInfo: StoreSearchResult? = null
+        firstStoreInfo: LocationStore,
+        secondStoreInfo: LocationStore? = null
     ) {
         setViewVisibility(firstVisibility, secondVisibility)
 
@@ -258,19 +262,23 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
 
     private fun moveToStoreDetail() {
         binding.clSearchFirstStoreInfo.setOnClickListener {
+            viewModel.locationStoreList.value?.get(0)
+                ?.let { store -> viewModel.updateSelectedStoreId(store.storeId) }
             val toStoreDetail = Intent(requireActivity(), StoreDetailActivity::class.java).putExtra(
-                "storeId",
+                STORE_ID,
                 viewModel.selectedStoreId.value
             )
             startActivity(toStoreDetail)
         }
         binding.clSearchSecondStoreInfo.setOnClickListener {
+            viewModel.locationStoreList.value?.get(1)
+                ?.let { store -> viewModel.updateSelectedStoreId(store.storeId) }
             val toStoreDetail = Intent(requireActivity(), StoreDetailActivity::class.java)
             startActivity(toStoreDetail)
         }
     }
 
-    //TODO 지도 움직일 때마다, 재검색 버튼이 뜨게 하기
+    // TODO 지도 움직일 때마다, 재검색 버튼이 뜨게 하기
     private fun clickReloadBtn() {
         binding.btnSearchReload.setOnClickListener {
             viewModel.updateCurrentPosition(
@@ -290,5 +298,23 @@ class SearchFragment : BindingFragment<FragmentSearchBinding>(R.layout.fragment_
 
     companion object {
         private const val LOCATION_PERMISSION_REQUEST_CODE = 1000
+    }
+
+    override fun onPOIItemSelected(p0: MapView?, p1: MapPOIItem?) {
+        val storeId = p1?.tag ?: 0
+        viewModel.findCoordinatesByStoreId(storeId)
+    }
+
+    override fun onCalloutBalloonOfPOIItemTouched(p0: MapView?, p1: MapPOIItem?) {
+    }
+
+    override fun onCalloutBalloonOfPOIItemTouched(
+        p0: MapView?,
+        p1: MapPOIItem?,
+        p2: MapPOIItem.CalloutBalloonButtonType?
+    ) {
+    }
+
+    override fun onDraggablePOIItemMoved(p0: MapView?, p1: MapPOIItem?, p2: MapPoint?) {
     }
 }

--- a/app/src/main/java/com/sookmyung/carryus/ui/search/SearchFragment.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/search/SearchFragment.kt
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
 import android.os.Bundle
+import android.os.Parcelable
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
@@ -256,6 +257,10 @@ class SearchFragment :
     private fun moveToSearchList() {
         binding.fabSearch.setOnClickListener {
             val toSearchList = Intent(requireActivity(), SearchListActivity::class.java)
+            val bundle = Bundle()
+            val searchStoreArrayList = ArrayList<Parcelable>(viewModel.searchStoreList.value.orEmpty())
+            bundle.putParcelableArrayList("searchStoreList", searchStoreArrayList)
+            toSearchList.putExtra("searchStoreList", bundle)
             startActivity(toSearchList)
         }
     }

--- a/app/src/main/java/com/sookmyung/carryus/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/search/SearchViewModel.kt
@@ -1,12 +1,13 @@
 package com.sookmyung.carryus.ui.search
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sookmyung.carryus.domain.entity.LocationStore
 import com.sookmyung.carryus.domain.entity.Position
 import com.sookmyung.carryus.domain.entity.StoreSearchResult
+import com.sookmyung.carryus.domain.usecase.GetLocationStoreList
 import com.sookmyung.carryus.domain.usecase.GetUserLocationStoreList
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -15,7 +16,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
-    private val getUserLocationStoreList: GetUserLocationStoreList
+    private val getUserLocationStoreList: GetUserLocationStoreList,
+    private val getLocationStoreList: GetLocationStoreList
 ) : ViewModel() {
     private val _currentLocation: MutableLiveData<Position> = MutableLiveData(Position(0.0, 0.0))
     val currentLocation: LiveData<Position> get() = _currentLocation
@@ -26,8 +28,11 @@ class SearchViewModel @Inject constructor(
     private val _searchStoreList: MutableLiveData<List<StoreSearchResult>> = MutableLiveData()
     val searchStoreList: LiveData<List<StoreSearchResult>> get() = _searchStoreList
 
-    //TODO 검색 반환 결과로 재검색 할게요 버튼 visible 처리
-    private val _isSearchSuccess: MutableLiveData<Boolean> = MutableLiveData(true)
+    private val _locationStoreList: MutableLiveData<List<LocationStore>> = MutableLiveData()
+    val locationStoreList: LiveData<List<LocationStore>> get() = _locationStoreList
+
+    // TODO 검색 반환 결과로 재검색 할게요 버튼 visible 처리
+    private val _isSearchSuccess: MutableLiveData<Boolean> = MutableLiveData(false)
     val isSearchSuccess: LiveData<Boolean> get() = _isSearchSuccess
     private val minX: MutableLiveData<Double> = MutableLiveData()
     private val maxX: MutableLiveData<Double> = MutableLiveData()
@@ -41,20 +46,44 @@ class SearchViewModel @Inject constructor(
         updateUserLocationStoreList()
     }
 
+    private fun getLocationStore(latitude: Double, longitude: Double) {
+        viewModelScope.launch {
+            getLocationStoreList(latitude, longitude)
+                .onSuccess { response ->
+                    _locationStoreList.value = response
+                }.onFailure { throwable ->
+                    Timber.e("서버 통신 실패 -> ${throwable.message}")
+                }
+        }
+    }
+
+    fun findCoordinatesByStoreId(storeId: Int) {
+        _searchStoreList.value?.find { it.storeId == storeId }?.let { storeSearchResult ->
+            getLocationStore(storeSearchResult.latitude, storeSearchResult.longitude)
+        }
+    }
+
     private fun updateUserLocationStoreList() {
         viewModelScope.launch {
             getUserLocationStoreList(
-                minX.value ?: 0.0, maxX.value ?: 0.0, minY.value ?: 0.0, maxY.value
+                minX.value ?: 0.0,
+                maxX.value ?: 0.0,
+                minY.value ?: 0.0,
+                maxY.value
                     ?: 0.0
             )
                 .onSuccess { response ->
-                    _isSearchSuccess.value = true
+//                    _isSearchSuccess.value = true
                     _searchStoreList.value = response
                 }.onFailure { throwable ->
                     _isSearchSuccess.value = false
                     Timber.e("서버 통신 실패 -> ${throwable.message}")
                 }
         }
+    }
+
+    fun updateIsSearchSuccess(success: Boolean) {
+        _isSearchSuccess.value = success
     }
 
     fun updateCurrentLocation(position: Position) {

--- a/app/src/main/java/com/sookmyung/carryus/ui/search/SearchViewModel.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/search/SearchViewModel.kt
@@ -82,6 +82,10 @@ class SearchViewModel @Inject constructor(
         }
     }
 
+    fun clickReloadBtn() {
+        _locationStoreList.value = emptyList()
+    }
+
     fun updateIsSearchSuccess(success: Boolean) {
         _isSearchSuccess.value = success
     }

--- a/app/src/main/java/com/sookmyung/carryus/ui/search/list/SearchListActivity.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/search/list/SearchListActivity.kt
@@ -5,7 +5,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import com.sookmyung.carryus.R
 import com.sookmyung.carryus.databinding.ActivitySearchListBinding
-import com.sookmyung.carryus.ui.search.SearchViewModel
+import com.sookmyung.carryus.domain.entity.StoreSearchResult
 import com.sookmyung.carryus.ui.search.storedetail.StoreDetailActivity
 import com.sookmyung.carryus.ui.search.storedetail.StoreDetailActivity.Companion.STORE_ID
 import com.sookmyung.carryus.util.binding.BindingActivity
@@ -14,7 +14,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class SearchListActivity :
     BindingActivity<ActivitySearchListBinding>(R.layout.activity_search_list) {
-    private val viewModel by viewModels<SearchViewModel>()
+    private val viewModel by viewModels<SearchListViewModel>()
     private val searchResultAdapter: SearchResultAdapter?
         get() = binding.rvSearchListStoreList.adapter as? SearchResultAdapter
 
@@ -22,9 +22,21 @@ class SearchListActivity :
         super.onCreate(savedInstanceState)
         binding.viewModel = viewModel
 
+        getBundleData()
         setSearchResultAdapter()
         setSearchResultObserver()
         moveToStoreDetail()
+    }
+
+    private fun getBundleData() {
+        val bundle = intent.getBundleExtra("searchStoreList")
+        val searchStoreList = bundle?.getParcelableArrayList<StoreSearchResult>("searchStoreList")
+
+        if (searchStoreList != null) {
+            viewModel.updateSearchStoreList(searchStoreList)
+        } else {
+            viewModel.updateSearchStoreList(emptyList())
+        }
     }
 
     private fun setSearchResultAdapter() {
@@ -34,14 +46,17 @@ class SearchListActivity :
     }
 
     private fun setSearchResultObserver() {
-        viewModel.searchStoreList.observe(this) { list ->
-            searchResultAdapter?.submitList(list)
+        binding.viewModel?.searchStoreList?.observe(this) { storeList ->
+            searchResultAdapter?.submitList(storeList)
         }
     }
 
-    private fun moveToStoreDetail(){
-        viewModel.selectedStoreId.observe(this){
-            val toStoreDetail = Intent(this, StoreDetailActivity::class.java).putExtra(STORE_ID, viewModel.selectedStoreId.value)
+    private fun moveToStoreDetail() {
+        viewModel.selectedStoreId.observe(this) {
+            val toStoreDetail = Intent(this, StoreDetailActivity::class.java).putExtra(
+                STORE_ID,
+                viewModel.selectedStoreId.value
+            )
             startActivity(toStoreDetail)
         }
     }

--- a/app/src/main/java/com/sookmyung/carryus/ui/search/list/SearchListViewModel.kt
+++ b/app/src/main/java/com/sookmyung/carryus/ui/search/list/SearchListViewModel.kt
@@ -1,0 +1,26 @@
+package com.sookmyung.carryus.ui.search.list
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.sookmyung.carryus.domain.entity.StoreSearchResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchListViewModel @Inject constructor() : ViewModel() {
+
+    private val _searchStoreList: MutableLiveData<List<StoreSearchResult>> = MutableLiveData()
+    val searchStoreList: LiveData<List<StoreSearchResult>> get() = _searchStoreList
+
+    private val _selectedStoreId: MutableLiveData<Int> = MutableLiveData()
+    val selectedStoreId: LiveData<Int> get() = _selectedStoreId
+
+    fun updateSearchStoreList(storeList: List<StoreSearchResult>) {
+        _searchStoreList.value = storeList
+    }
+
+    fun updateSelectedStoreId(storeId: Int) {
+        _selectedStoreId.value = storeId
+    }
+}

--- a/app/src/main/res/layout/activity_search_list.xml
+++ b/app/src/main/res/layout/activity_search_list.xml
@@ -9,7 +9,7 @@
 
         <variable
             name="viewModel"
-            type="com.sookmyung.carryus.ui.search.SearchViewModel" />
+            type="com.sookmyung.carryus.ui.search.list.SearchListViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -61,7 +61,7 @@
             android:paddingVertical="7dp"
             android:text="@string/search_reload"
             android:textColor="@color/white000"
-            android:visibility="visible"
+            android:visibility="@{viewModel.isSearchSuccess == false ? View.VISIBLE : View.GONE}"
             app:drawableEndCompat="@drawable/ic_reload"
             app:drawableTint="@color/white000"
             app:layout_constraintEnd_toEndOf="parent"
@@ -90,6 +90,7 @@
             android:layout_marginHorizontal="18dp"
             android:layout_marginBottom="16dp"
             android:background="@color/white000"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">
@@ -159,6 +160,7 @@
             android:layout_marginHorizontal="18dp"
             android:layout_marginBottom="16dp"
             android:background="@color/white000"
+            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@id/cl_search_first_store_info"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent">


### PR DESCRIPTION
# 📑 Summary
* 위치 기반 스토어 정보 조회해서 밑에 리스트로 띄웁니다! 현재 더미는 2개인 경우가 없어서, 지금 1개씩만 뜨고 있습니다.

## 📸 Screen Shot

https://github.com/CARRY-US/CarryUs-Android/assets/91793891/b7e412a2-4af9-43cb-bbb7-b05c573213e5


## ➰ Associated Issue
* close #24 

### 📬 To Reviewers
* 코드가 많이 더럽네요,, 읽기 힘들게 만든 점 죄송합니닷,,
